### PR TITLE
Enhance .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ node_modules
 *.rdb
 
 .DS_Store
+.AppleDouble
+.LSOverride
+Icon


### PR DESCRIPTION
Add OS X-specific files that are created when git directory is located on a remote drive.
