### PR TITLE
Allow redirects under multiple levels of subdirectories

### DIFF
--- a/controllers/RedirectController.js
+++ b/controllers/RedirectController.js
@@ -4,7 +4,7 @@ module.exports = function(redis) {
   var RedirectController = {};
 
   RedirectController.redirect = function(req, res) {
-    var redirectName = req.params.redirect_name;
+    var redirectName = req.params[0];
     Redirect.get(redirectName, function(err, redirect) {
       if (err)
         res.status(500).send(err);

--- a/models/Redirect.js
+++ b/models/Redirect.js
@@ -53,7 +53,7 @@ module.exports = function(redis) {
   };
 
   Redirect.delete = function(key, callback) {
-    key = decodeURIComponent(key.toLowerCase()).replace(/[^a-z0-9_]/g,'-');
+    key = decodeURIComponent(key.toLowerCase()).replace(/[^a-z0-9_\/]/g,'-');
     redis.del(urlKeyPrefix+key, clicksKeyPrefix+key, function(err, result) {
       if (err) {
         callback(err);

--- a/models/Redirect.js
+++ b/models/Redirect.js
@@ -26,7 +26,7 @@ module.exports = function(redis) {
   var Redirect = {};
 
   Redirect.get = function(key, callback) {
-    key = decodeURIComponent(key.toLowerCase()).replace(/[^a-z0-9_]/g,'-');
+    key = decodeURIComponent(key.toLowerCase()).replace(/[^a-z0-9_\/]/g,'-');
     redis.multi({ pipeline: false });
     redis.get(urlKeyPrefix+key);
     redis.get(clicksKeyPrefix+key);
@@ -39,7 +39,7 @@ module.exports = function(redis) {
   };
 
   Redirect.create = function(key, url, callback) {
-    key = decodeURIComponent(key.toLowerCase()).replace(/[^a-z0-9_]/g,'-');
+    key = decodeURIComponent(key.toLowerCase()).replace(/[^a-z0-9_\/]/g,'-');
     redis.multi({ pipeline: false });
     redis.set(urlKeyPrefix+key, url);
     redis.set(clicksKeyPrefix+key, 0);

--- a/routes/main.js
+++ b/routes/main.js
@@ -5,6 +5,6 @@ module.exports = function(rootRedirect, redirectController) {
   router.get('/', function(req, res) {
   	res.redirect(rootRedirect);
   })
-  router.get('/:redirect_name', redirectController.redirect);
+  router.get('/*', redirectController.redirect);
   return router;
 };


### PR DESCRIPTION
This feature allows you to place redirects in "subfolders".

This makes it easier to organise related links. For example...

- https://qais.jp/cv (just my cv)
  * https://qais.jp/cv/myed (a short link)
  * https://qais.jp/cv/edit (a personal edit link)
- https://qais.jp/mta (something might be here one day)
  * https://qais.jp/mta/discord (discord link for mta)

